### PR TITLE
add common java classes

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -128,6 +128,18 @@ jobs:
             java.base/share/classes/java/util/Optional.java
             java.base/share/classes/java/util/logging/Logger.java
             java.base/share/classes/java/lang/Class.java
+            java.base/share/classes/java/lang/String.java
+            java.base/share/classes/java/lang/StringBuilder.java
+            java.base/share/classes/java/lang/Number.java
+            java.base/share/classes/java/lang/Integer.java
+            java.base/share/classes/java/lang/Short.java
+            java.base/share/classes/java/lang/Byte.java
+            java.base/share/classes/java/lang/Double.java
+            java.base/share/classes/java/lang/Float.java
+            java.base/share/classes/java/lang/Boolean.java
+            java.base/share/classes/java/lang/Math.java
+            java.base/share/classes/java/math/BigInteger.java
+            java.base/share/classes/java/math/BigDecimal.java
           )
 
           FILES=""

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -128,6 +128,7 @@ jobs:
             java.base/share/classes/java/util/Optional.java
             java.base/share/classes/java/util/logging/Logger.java
             java.base/share/classes/java/lang/Class.java
+            java.base/share/classes/java/lang/System.java
             java.base/share/classes/java/lang/String.java
             java.base/share/classes/java/lang/StringBuilder.java
             java.base/share/classes/java/lang/Number.java


### PR DESCRIPTION
`String`, `StringBuilder`, `Number`, `Integer`, `Short`, `Byte`, `Double`, `Float`, `Boolean`, `Math`, `BigInteger`, `BigDecimal`

Some of these have their Lua equivalents but sometimes you are forced to use and operate on Java type, eg. when dealing with generics. Additionally, classes like `String`, `StringBuilder` and `BigInteger` or `BigDecimal`, contain a lot of utility methods that are missing from Lua standard library. This makes accessing them much quicker.

Not tested but I made sure paths are correct.